### PR TITLE
fix "list index out of range" error for fc_drop

### DIFF
--- a/cfg/SincNet_Librispeech.cfg
+++ b/cfg/SincNet_Librispeech.cfg
@@ -34,7 +34,7 @@ fc_act=leaky_relu,linear,leaky_relu
 
 [class]
 class_lay= 2484
-class_drop=0.0,0.0
+class_drop=0.0,0.0,0.0
 class_use_laynorm_inp=True
 class_use_batchnorm_inp=False
 class_use_batchnorm=False


### PR DESCRIPTION
The current LibriSpeech configuration throws an error due to the missing third variable for fc_drop. We can either reduce the number of the fully connected layer (fc_lay) or increase the dropout probability (fc_drop) variables to match up with N_fc_lay.