### PR TITLE
fix pickle error when loading class_dict_file

### DIFF
--- a/speaker_id.py
+++ b/speaker_id.py
@@ -170,7 +170,7 @@ CNN_net=CNN(CNN_arch)
 CNN_net.cuda()
 
 # Loading label dictionary
-lab_dict=np.load(class_dict_file).item()
+lab_dict=np.load(class_dict_file, allow_pickle=True).item()
 
 
 


### PR DESCRIPTION
numpy.save has the allow_pickle=True as default while numpy.load has allow_pickle=False, so this raises an error that can be fixed by explicitly setting the allow_pickle variable.